### PR TITLE
allow for passing global data via the config object

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,3 +1,4 @@
+var extend = require('util')._extend;
 var fs     = require('fs');
 var path   = require('path');
 var rimraf = require('rimraf');
@@ -8,6 +9,9 @@ var yaml   = require('js-yaml');
 module.exports = function(data) {
   // Render a template with the component's data and write it to disk
   var output = '';
+
+  // Extend file data with global data
+  extend(data, this.options.data);
 
   // Catch Handlebars errors, because they won't show up in the Gulp console
   try {

--- a/test/fixtures/template.html
+++ b/test/fixtures/template.html
@@ -93,3 +93,7 @@
 
 </section>
 {{/if}}
+
+{{#if project}}
+<p>Used in: <strong>{{ project }}</strong></p>
+{{/if}}

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,10 @@ var CONFIG = {
     'sass': { verbose: false }
   },
   marked: require('./fixtures/marked'),
-  handlebars: require('./fixtures/handlebars')
+  handlebars: require('./fixtures/handlebars'),
+  data: {
+    'project': 'Large Hadron'
+  }
 }
 
 describe('Supercollider', function() {


### PR DESCRIPTION
Adds the ability to pass data via the config object so that it can be used in each file.

I can see a future need for passing a file (just JSON, probably), but this solves the basic need.
Does not support command line use currently, as passing a file would almost certainly be required.
If you'd like to see file-passing and/or command line support implemented before merging, I'd be happy to do so.